### PR TITLE
Fix syntax error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,7 @@ var Q = require("Q");
 
 function Client(opts) {
     if (!opts.serviceUrl) throw new Error('serviceUrl is required');
-    
+
     var self = this;
     this.serviceUrl = opts.serviceUrl;
 }
@@ -31,7 +31,7 @@ Client.prototype.get = function (opts, cb) {
         }
 
         if (response.statusCode !== 200) {
-            var error = new Error('Error invoking web request, statusCode: ' + statusCode);
+            var error = new Error('Error invoking web request, statusCode: ' + response.statusCode);
             deferred.reject(error);
             return cb(error)
         }


### PR DESCRIPTION
Must have been throwing an exception that was invisibly caught somewhere. Common problem with promises.

Also.. why use Q when ES6 native promises do everything you're doing here?
